### PR TITLE
Fix timeout when establishing connection

### DIFF
--- a/ignition/request.py
+++ b/ignition/request.py
@@ -91,8 +91,7 @@ class Request:
     '''
 
     try:
-      sock = socket.create_connection((self.__url.host(), self.__url.port()))
-      sock.settimeout(self.timeout)
+      sock = socket.create_connection((self.__url.host(), self.__url.port()), timeout=self.timeout)
       logger.debug(f"Created socket connection: {sock}")
       return sock
     except ConnectionRefusedError as err:


### PR DESCRIPTION
Looks like `socket.create_connection()` is a blocking call, thus prior to change, hanging with the default system timeout before continuing if unable to establish a connection.