### PR TITLE
Fixes bugs with cert file parsing

### DIFF
--- a/ignition/globals.py
+++ b/ignition/globals.py
@@ -6,6 +6,7 @@ at http://mozilla.org/MPL/2.0/.
 '''
 
 CRLF = "\r\n"
+EOL = "\n"
 
 '''
 Gemini-Protocol Mechanical Constants

--- a/ignition/ssl/cert_record.py
+++ b/ignition/ssl/cert_record.py
@@ -9,6 +9,7 @@ import datetime
 from typing import Dict
 
 from ..globals import *
+from .exceptions import CertRecordParseException
 
 class CertRecord:
   '''
@@ -32,18 +33,21 @@ class CertRecord:
     Generate a CertRecord from a string in the format:
     [HOSTNAME] [SSH-ALGORITHM PUBLIC_KEY];EXPIRES=[YYYY-MM-DDTHH:mm:ss.SSSZ]
     '''
-    hostname, fingerprint_with_expiration = host_string.strip().split(' ', maxsplit=1)
-    fingerprint, expiration = fingerprint_with_expiration.split(';EXPIRES=')
-    expiration_datetime = datetime.datetime.fromisoformat(expiration)
+    try:
+      hostname, fingerprint_with_expiration = host_string.strip().split(' ', maxsplit=1)
+      fingerprint, expiration = fingerprint_with_expiration.split(';EXPIRES=')
+      expiration_datetime = datetime.datetime.fromisoformat(expiration)
 
-    return CertRecord(hostname, fingerprint, expiration_datetime)
+      return CertRecord(hostname, fingerprint, expiration_datetime)
+    except Exception as e:
+      raise CertRecordParseException()
 
   def to_string(self):
     '''
     Converts a CertRecord to a string in the format:
     [HOSTNAME] [SSH-ALGORITHM PUBLIC_KEY];EXPIRES=[YYYY-MM-DDTHH:mm:ss.SSSZ]
     '''
-    return self.hostname + ' ' + self.fingerprint + ';EXPIRES=' + self.expiration.isoformat() + CRLF
+    return self.hostname + ' ' + self.fingerprint + ';EXPIRES=' + self.expiration.isoformat() + EOL
 
   def is_expired(self):
     '''

--- a/ignition/ssl/exceptions.py
+++ b/ignition/ssl/exceptions.py
@@ -17,3 +17,9 @@ class TofuCertificateRejection(Exception):
   An exception type handle TOFU (trust-on-first-use rejection).
   '''
   pass
+
+class CertRecordParseException(Exception):
+  '''
+  An exception triggered on cert record parsing.
+  '''
+  pass

--- a/tests/ssl/test_cert_record.py
+++ b/tests/ssl/test_cert_record.py
@@ -10,6 +10,7 @@ import mock
 import unittest
 
 from ignition.ssl.cert_record import CertRecord
+from ignition.ssl.exceptions import CertRecordParseException
 
 
 class CertRecordTests(unittest.TestCase):
@@ -24,17 +25,22 @@ class CertRecordTests(unittest.TestCase):
     self.assertEqual(cert_record.expiration, self.test_datetime)
 
   def test_from_string(self):
-    cert_record = CertRecord.from_string('myhostname.sample ssh-rsa fingerprint;EXPIRES=2020-11-15T12:15:02.438000\r\n')
+    cert_record = CertRecord.from_string('myhostname.sample ssh-rsa fingerprint;EXPIRES=2020-11-15T12:15:02.438000\n')
     self.assertEqual(cert_record.hostname, 'myhostname.sample')
     self.assertEqual(cert_record.fingerprint, 'ssh-rsa fingerprint')
     self.assertEqual(cert_record.expiration, self.test_datetime)
     pass
 
+  def test_from_string_invalid(self):
+    self.assertRaises(CertRecordParseException, CertRecord.from_string, 'myhost.com\n')
+    self.assertRaises(CertRecordParseException, CertRecord.from_string, 'myhost.com ssh-rsa fingerprint;EXPIRES=invalid\n')
+    self.assertRaises(CertRecordParseException, CertRecord.from_string, '\n')
+
   def test_to_string(self):
     cert_record = CertRecord('myhostname.sample', 'ssh-rsa fingerprint', self.test_datetime)
     self.assertEqual(
       cert_record.to_string(),
-      'myhostname.sample ssh-rsa fingerprint;EXPIRES=2020-11-15T12:15:02.438000\r\n'
+      'myhostname.sample ssh-rsa fingerprint;EXPIRES=2020-11-15T12:15:02.438000\n'
     )
 
   @mock.patch('ignition.ssl.cert_record.datetime')


### PR DESCRIPTION
Fixes #10:

* Changes the behavior of the cert file schema to use `\n` rather than `\r\n`.
* Handles blank lines and other problematic lines by ignoring them when parsing and deleting on overwrite.

This should gracefully upgrade and fix existing errors in user environments.  No manual migration is required by users.