### PR TITLE
Set minimum TLS version to 1.2

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -289,6 +289,8 @@ This is a detailed status message for response type 0x (ERROR).
 
 This is a custom error type outside of the scope of the Gemini protocol.  03 errors represent any errors associated with TLS/SSL, including handshake errors, certificate expired errors, and security errors like certificate rejection errors.  See the message-level details in the `response.data()` to get additional information.
 
+Note that ignition now only supports services with TLS versions >= 1.2.
+
 #### RESPONSE_STATUSDETAIL_ERROR_PROTOCOL = "04"
 This is a detailed status message for response type 0x (ERROR).
 

--- a/ignition/__init__.py
+++ b/ignition/__init__.py
@@ -19,7 +19,7 @@ from .response import (
 from .ssl.cert_store import CertStore
 from .util import TimeoutManager
 
-__version__ = "0.1.13"
+__version__ = "0.2.0"
 
 __timeout = TimeoutManager(DEFAULT_REQUEST_TIMEOUT)
 __cert_store = CertStore(DEFAULT_HOSTS_FILE)

--- a/ignition/request.py
+++ b/ignition/request.py
@@ -318,6 +318,7 @@ class Request:
         """
 
         context = ssl.create_default_context()
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
         return context


### PR DESCRIPTION
As per 4.1 in the Gemini protocol specifications (https://gemini.circumlunar.space/docs/specification.gmi):

> Servers MUST use TLS version 1.2 or higher and SHOULD use TLS version 1.3 or higher. TLS 1.2 is reluctantly permitted for now to avoid drastically reducing the range of available implementation libraries. Hopefully TLS 1.3 or higher can be specced in the near future. Clients who wish to be "ahead of the curve MAY refuse to connect to servers using TLS version 1.2 or lower.

Given the security issues around 1.0 and 1.1 ignition will only allow connectivity to TLS >= 1.2.

Includes documentation changes
